### PR TITLE
tasks/configuration.yml: restart corosync only if it is needed

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -9,7 +9,7 @@
 - name: Making sure that Corosync service is started
   ansible.builtin.systemd:
     name: corosync
-    state: restarted
+    state: started
     enabled: yes
 
 - meta: flush_handlers


### PR DESCRIPTION
Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>