### PR TITLE
Set corosync priority to OTHER (nice -20) instead of RR99

### DIFF
--- a/templates/etc/corosync/corosync.conf.j2
+++ b/templates/etc/corosync/corosync.conf.j2
@@ -1,4 +1,8 @@
 # {{ ansible_managed }}
+system {
+  sched_rr: no
+  priority: -20
+}
 totem {
 	version: 2
 {% if corosync_transport is defined and corosync_transport == 'knet' %} 


### PR DESCRIPTION
Following this discussion, I suggest we try to run corosync with a non realtime priority.

https://github.com/corosync/corosync/issues/706

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>