### PR TITLE
tasks/main: use import_tasks instead of include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # file: roles/corosync/main.yml
-- include: auth.yml
+- import_tasks: auth.yml
   tags: [ corosync, corosync-auth ]
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags: [ corosync, corosync-config ]


### PR DESCRIPTION
The include directive is being deprecated in favor of import_tasks.